### PR TITLE
Don't transform ES modules.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 module.exports = {
   presets: [
-    require('babel-preset-env'),
+    [require('babel-preset-env'), {
+      modules: false
+    }],
     require('babel-preset-react'),
   ],
   plugins: [

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.0.0",
   "description": "Shared Babel preset for DoSomething.org projects.",
   "engines": {
-    "node": ">= 4.0.0",
-    "npm": ">= 3.0.0"
+    "node": ">= 6.0.0",
+    "npm": ">= 5.0.0"
   },
   "main": "index.js",
   "scripts": {
@@ -13,14 +13,11 @@
   "author": "David Furnes <dfurnes@dosomething.org>",
   "license": "MIT",
   "dependencies": {
-    "babel-preset-env": "^1.4.0",
-    "babel-plugin-lodash": "^3.2.11",
-    "babel-preset-react": "^6.22.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-plugin-lodash": "^3.3.2",
+    "babel-preset-react": "^6.24.1",
     "babel-preset-react-optimize": "^1.0.1",
     "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0"
-  },
-  "devDependencies": {
-    "babel-plugin-lodash": "^3.2.11"
+    "babel-plugin-transform-object-rest-spread": "^6.26.0"
   }
 }


### PR DESCRIPTION
In order to [enable scope hosting](https://github.com/DoSomething/webpack-config/pull/11) with Webpack 3, we need Babel to export ES6 modules (rather than transforming them to ES5). This adds an option to our base babel preset so we do that! I also did a quick audit of our dependencies to make sure we're on the latest Babel 6 release for each one.