### PR TITLE
Only include polyfills for supported browsers.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,9 @@ module.exports = {
     [require('babel-preset-env'), {
       // Jest needs CommonJS modules to run in Node. If building for
       // Webpack 3, don't compile modules so we can use scope hoisting.
-      modules: runningTests ? 'commonjs' : false
+      modules: runningTests ? 'commonjs' : false,
+      // Replace 'babel-polyfill' with only polyfills for target browsers.
+      useBuiltIns: true,
     }],
     require('babel-preset-react'),
   ],

--- a/index.js
+++ b/index.js
@@ -3,6 +3,11 @@ const runningTests = process.env.NODE_ENV === 'test';
 module.exports = {
   presets: [
     [require('babel-preset-env'), {
+      // We only target the latest 2 versions of browsers & Firefox
+      // ESR (schools!), excluding "dead" browsers (<0.5% global usage).
+      targets: {
+        browsers: ['last 2 versions', 'Firefox ESR', 'not dead'],
+      },
       // Jest needs CommonJS modules to run in Node. If building for
       // Webpack 3, don't compile modules so we can use scope hoisting.
       modules: runningTests ? 'commonjs' : false,


### PR DESCRIPTION
This pull request updates adds the `useBuiltIns` setting to our `babel-preset-env` config to trim out polyfills that aren't needed.

We support the default browsers specified by [browserslist](https://github.com/browserslist/browserslist), which is > 0.5% global usage, last 2 versions, Firefox ESR, not dead (excludes IE10, Blackberry 10, Blackberry 7 from the "last 2 versions" query).