### PR TITLE
Set our supported browsers as Babel targets.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const runningTests = process.env.NODE_ENV === 'test';
 module.exports = {
   presets: [
     [require('babel-preset-env'), {
+      // Set our supported browsers. <goo.gl/w43BMg>
+      targets: {
+        browsers: ['>0.5%', 'ie 11', 'not op_mini all'],
+      },
       // Jest needs CommonJS modules to run in Node. If building for
       // Webpack 3, don't compile modules so we can use scope hoisting.
       modules: runningTests ? 'commonjs' : false,


### PR DESCRIPTION
Following up on my failed attempt in #4, here's the real deal (after getting a kick from reading [this post](https://jamie.build/last-2-versions))! This sets our [supported browsers](goo.gl/w43BMg), and reduces Phoenix Next's app bundle size from 183kb to... 183kb.

Oh well! Once we feel good to drop IE11 support, we can get down to 143kb...! 🙆‍♂️ 