### PR TITLE
Update for Babel 7.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2019 DoSomething.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Specify as a preset in your `package.json`:
 {
   // ...
   "babel": {
-    "preset": "@dosomething/babel-preset",
+    "presets": ["@dosomething"],
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ We've also enabled support for the [export extensions](https://github.com/babel/
 Install this package via NPM: 
 
 ```
-npm install @babel/core @dosomething/babel-config core-js --save-dev
+npm install @babel/core @dosomething/babel-preset --save-dev
+npm install @babel/runtime core-js --save
 ```
 
 Specify as a preset in your `package.json`:
@@ -19,7 +20,7 @@ Specify as a preset in your `package.json`:
 {
   // ...
   "babel": {
-    "preset": "@dosomething/babel-config",
+    "preset": "@dosomething/babel-preset",
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# babel-config
+# babel-preset
 
-This is our shared [Babel](http://babeljs.io) config, used when compiling JavaScript for the web at [DoSomething.org](https://www.dosomething.org/).
+This is our shared [Babel](http://babeljs.io) preset, used when compiling JavaScript for the web at [DoSomething.org](https://www.dosomething.org/).
 
 It adds support for the [latest language features](https://babeljs.io/docs/en/babel-preset-env) in older browsers, [React's JSX syntax](https://babeljs.io/docs/en/babel-preset-react) (with optimizations for [faster re-renders](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements) and [smaller production builds](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)!), [pre-compiled GraphQL queries](https://www.apollographql.com/docs/react/recipes/babel#using-babel-plugin-graphql-tag), and dynamic imports (for [Webpack](https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import) and [Node](https://github.com/airbnb/babel-plugin-dynamic-import-node)).
 
@@ -26,6 +26,6 @@ Specify as a preset in your `package.json`:
 ```
 
 ### License
-&copy; DoSomething.org. Our Babel config is free software, and may be redistributed under the
-terms specified in the [LICENSE](https://github.com/DoSomething/babel-config/blob/master/LICENSE) file. The
+&copy; DoSomething.org. Our Babel preset is free software, and may be redistributed under the
+terms specified in the [LICENSE](https://github.com/DoSomething/babel-preset/blob/master/LICENSE) file. The
 name and logo for DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We've also enabled support for the [export extensions](https://github.com/babel/
 Install this package via NPM: 
 
 ```
-npm install @babel/core @dosomething/babel-config --save-dev
+npm install @babel/core @dosomething/babel-config core-js --save-dev
 ```
 
 Specify as a preset in your `package.json`:

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # babel-config
 
-This is our shared [Babel](http://babeljs.io) config used for writing JavaScript at DoSomething.org. It compiles the [latest ECMAScript standard](https://github.com/babel/babel-preset-env) to ES5 for widespread browser support, adds support for [JSX & Flow](https://github.com/babel/babel/tree/master/packages/babel-preset-react) (with [optimizations](https://github.com/thejameskyle/babel-react-optimize)!), and adds support for experimental [export extensions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-export-extensions) and [object spread properties](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-rest-spread).
+This is our shared [Babel](http://babeljs.io) config, used when compiling JavaScript for the web at [DoSomething.org](https://www.dosomething.org/). It transforms the [latest ECMAScript language features](https://babeljs.io/docs/en/babel-preset-env) to ES5 for widespread browser support & adds [support for React](https://babeljs.io/docs/en/babel-preset-react) (with optimizations for [constant elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements) and [smaller production builds](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)!).
+
+We've also enabled support for the [export extensions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-export-extensions) and [object spread properties](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-rest-spread) proposals.
 
 ### Getting Started
 Install this package via NPM: 
 
 ```
-npm install @dosomething/babel-config --save-dev
+npm install @babel/core @dosomething/babel-config --save-dev
 ```
 
 Specify as a preset in your `package.json`:
@@ -21,6 +23,6 @@ Specify as a preset in your `package.json`:
 ```
 
 ### License
-&copy;2017 DoSomething.org. @dosomething/babel-config is free software, and may be redistributed under the
-terms specified in the [LICENSE](https://github.com/DoSomething/webpack-config/blob/master/LICENSE) file. The
+&copy; DoSomething.org. Our Babel config is free software, and may be redistributed under the
+terms specified in the [LICENSE](https://github.com/DoSomething/babel-config/blob/master/LICENSE) file. The
 name and logo for DoSomething.org are trademarks of Do Something, Inc and may not be used without permission.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # babel-config
 
-This is our shared [Babel](http://babeljs.io) config, used when compiling JavaScript for the web at [DoSomething.org](https://www.dosomething.org/). It transforms the [latest ECMAScript language features](https://babeljs.io/docs/en/babel-preset-env) to ES5 for widespread browser support & adds [support for React](https://babeljs.io/docs/en/babel-preset-react) (with optimizations for [constant elements](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements) and [smaller production builds](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)!).
+This is our shared [Babel](http://babeljs.io) config, used when compiling JavaScript for the web at [DoSomething.org](https://www.dosomething.org/).
+
+It adds support for the [latest language features](https://babeljs.io/docs/en/babel-preset-env) in older browsers, [React's JSX syntax](https://babeljs.io/docs/en/babel-preset-react) (with optimizations for [faster re-renders](https://babeljs.io/docs/en/babel-plugin-transform-react-constant-elements) and [smaller production builds](https://github.com/oliviertassinari/babel-plugin-transform-react-remove-prop-types)!), [pre-compiled GraphQL queries](https://www.apollographql.com/docs/react/recipes/babel#using-babel-plugin-graphql-tag), and dynamic imports (for [Webpack](https://babeljs.io/docs/en/babel-plugin-syntax-dynamic-import) and [Node](https://github.com/airbnb/babel-plugin-dynamic-import-node)).
 
 We've also enabled support for the [export extensions](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-export-extensions) and [object spread properties](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-object-rest-spread) proposals.
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const runningTests = process.env.NODE_ENV === 'test';
 
-module.exports = {
+module.exports = () => ({
   presets: [
     [require('@babel/preset-env'), {
       // Set our supported browsers. <goo.gl/w43BMg>
@@ -38,4 +38,4 @@ module.exports = {
       ],
     },
   },
-};
+});

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = {
     require('@babel/preset-react'),
   ],
   plugins: [
+    require('@babel/plugin-transform-runtime'),
     require('@babel/plugin-proposal-object-rest-spread'),
     require('@babel/plugin-proposal-class-properties'),
     require('@babel/plugin-syntax-dynamic-import'),

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = () => ({
       modules: runningTests ? 'commonjs' : false,
       // Replace 'babel-polyfill' with only polyfills for target browsers.
       useBuiltIns: 'usage',
+      corejs: 3,
     }],
     require('@babel/preset-react'),
   ],

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const runningTests = process.env.NODE_ENV === 'test';
 
 module.exports = {
   presets: [
-    [require('babel-preset-env'), {
+    [require('@babel/preset-env'), {
       // Set our supported browsers. <goo.gl/w43BMg>
       targets: {
         browsers: ['>0.5%', 'ie 11', 'not op_mini all'],
@@ -13,18 +13,19 @@ module.exports = {
       // Replace 'babel-polyfill' with only polyfills for target browsers.
       useBuiltIns: true,
     }],
-    require('babel-preset-react'),
+    require('@babel/preset-react'),
   ],
   plugins: [
-    require('babel-plugin-lodash'),
+    require('@babel/plugin-proposal-object-rest-spread'),
+    require('@babel/plugin-proposal-class-properties'),
     require('babel-plugin-transform-export-extensions'),
-    require('babel-plugin-transform-object-rest-spread'),
-    require('babel-plugin-transform-class-properties'),
+    require('babel-plugin-lodash'),
   ],
   env: {
     production: {
-      presets: [
-        require('babel-preset-react-optimize'),
+      plugins: [
+        require('@babel/plugin-transform-react-constant-elements')
+        require('babel-plugin-transform-react-remove-prop-types')
       ]
     },
   },

--- a/index.js
+++ b/index.js
@@ -18,15 +18,23 @@ module.exports = {
   plugins: [
     require('@babel/plugin-proposal-object-rest-spread'),
     require('@babel/plugin-proposal-class-properties'),
-    require('babel-plugin-transform-export-extensions'),
+    require('@babel/plugin-syntax-dynamic-import'),
+    require('@babel/plugin-proposal-export-default-from'),
+    require('@babel/plugin-proposal-export-namespace-from'),
+    require('babel-plugin-graphql-tag'),
     require('babel-plugin-lodash'),
   ],
   env: {
     production: {
       plugins: [
-        require('@babel/plugin-transform-react-constant-elements')
-        require('babel-plugin-transform-react-remove-prop-types')
-      ]
+        require('@babel/plugin-transform-react-constant-elements'),
+        require('babel-plugin-transform-react-remove-prop-types'),
+      ],
+    },
+    test: {
+      plugins: [
+        require('babel-plugin-dynamic-import-node'),
+      ],
     },
   },
 };

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = () => ({
       // Webpack 3, don't compile modules so we can use scope hoisting.
       modules: runningTests ? 'commonjs' : false,
       // Replace 'babel-polyfill' with only polyfills for target browsers.
-      useBuiltIns: true,
+      useBuiltIns: 'usage',
     }],
     require('@babel/preset-react'),
   ],

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "author": "David Furnes <dfurnes@dosomething.org>",
   "license": "MIT",
   "peerDependencies": {
-    "@babel/core": "^7.0.0"
+    "@babel/core": "^7.0.0",
+    "@babel/runtime": "^7.0.0"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/core": "^7.0.0",
-    "@babel/runtime": "^7.0.0"
+    "@babel/runtime": "^7.0.0",
+    "core-js": "^3.0.1"
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",
@@ -29,7 +30,6 @@
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-graphql-tag": "^2.1.0",
     "babel-plugin-lodash": "^3.3.4",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
-    "core-js": "^3.0.1"
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dosomething/babel-config",
+  "name": "@dosomething/babel-preset",
   "version": "2.2.2",
   "description": "Shared Babel preset for DoSomething.org projects.",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.2.2",
   "description": "Shared Babel preset for DoSomething.org projects.",
   "engines": {
-    "node": ">= 6.0.0",
-    "npm": ">= 5.0.0"
+    "node": ">= 10.0.0",
+    "npm": ">= 6.0.0"
   },
   "main": "index.js",
   "scripts": {
@@ -12,13 +12,15 @@
   },
   "author": "David Furnes <dfurnes@dosomething.org>",
   "license": "MIT",
+  "peerDependencies": {
+    "@babel/core": "^7.0.0"
+  },
   "dependencies": {
-    "babel-plugin-lodash": "^3.3.2",
-    "babel-plugin-transform-class-properties": "^6.24.1",
-    "babel-plugin-transform-export-extensions": "^6.22.0",
-    "babel-plugin-transform-object-rest-spread": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-react": "^6.24.1",
-    "babel-preset-react-optimize": "^1.0.1"
+    "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+    "@babel/plugin-transform-react-constant-elements": "^7.2.0",
+    "@babel/preset-env": "^7.4.4",
+    "@babel/preset-react": "^7.0.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,17 +18,18 @@
   },
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",
+    "@babel/plugin-proposal-export-default-from": "^7.2.0",
+    "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
-    "@babel/plugin-proposal-export-default-from": "^7.2.0",
-    "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-react": "^7.0.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "babel-plugin-graphql-tag": "^2.1.0",
     "babel-plugin-lodash": "^3.3.4",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
+    "core-js": "^3.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,16 @@
   "dependencies": {
     "@babel/plugin-proposal-class-properties": "^7.4.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.4.4",
+    "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-transform-react-constant-elements": "^7.2.0",
+    "@babel/plugin-proposal-export-default-from": "^7.2.0",
+    "@babel/plugin-proposal-export-namespace-from": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.4.4",
     "@babel/preset-react": "^7.0.0",
+    "babel-plugin-dynamic-import-node": "^2.2.0",
+    "babel-plugin-graphql-tag": "^2.1.0",
+    "babel-plugin-lodash": "^3.3.4",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24"
   }
 }


### PR DESCRIPTION
This pull request updates our Babel config for Babel 7.x! Here's the breakdown:

7️⃣ Updated "first-party" preset & plugin packages with the new `@babel/` scoped names.

📛 Renamed package from `@dosomething/babel-config` to `@dosomething/babel-preset` to match convention, and fix an awkward issue where [Babels' preset shorthands](https://babeljs.io/docs/en/presets#preset-shorthand) would cause the old package to try to load `@dosomething/babel-preset-babel-config`. Womp womp.

🐦 Moved some extensions from Phoenix into our base config so they're available everywhere.

👨‍🎓 Added peer dependencies on the appropriate `@babel/core`, `@babel/runtime` & `core-js` versions, so this isn't something we have to implicitly maintain.

©️ Updated copyright in README & added missing LICENSE file.

Most of these changes were informed by the [upgrade guide](https://babeljs.io/docs/en/next/v7-migration).

References [#151738638](https://www.pivotaltracker.com/story/show/151738638).