### PR TITLE
Allow opting out of bundled polyfills.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,23 @@ Specify as a preset in your `package.json`:
 {
   // ...
   "babel": {
-    "presets": ["@dosomething"],
+    "presets": [
+      "@dosomething"
+    ]
+  }
+}
+```
+
+### Configuration
+By default, [polyfills](https://remysharp.com/2010/10/08/what-is-a-polyfill) for any newer platform features used in your application will be included in your compiled bundle. If this project doesn't support older browsers or is using a [polyfill service](https://polyfill.io/v3/), you can opt out like so:
+
+```js
+{
+  // ...
+  "babel": {
+    "presets": [
+      ["@dosomething", { "withPolyfills": false }]
+    ]
   }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -1,42 +1,50 @@
-const runningTests = process.env.NODE_ENV === 'test';
+module.exports = (api, { withPolyfills = true }) => {
+  const runningTests = process.env.NODE_ENV === 'test';
+  const polyfillSettings = withPolyfills ? {
+    useBuiltIns: withPolyfills ? 'usage' : false,
+    corejs: 3,
+  } : null;
 
-module.exports = () => ({
-  presets: [
-    [require('@babel/preset-env'), {
-      // Set our supported browsers. <goo.gl/w43BMg>
-      targets: {
-        browsers: ['>0.5%', 'ie 11', 'not op_mini all'],
+  return {
+    presets: [
+      [require('@babel/preset-env'), {
+        // Set our supported browsers. <goo.gl/w43BMg>
+        targets: {
+          browsers: ['>0.5%', 'ie 11', 'not op_mini all'],
+        },
+
+        // Jest needs CommonJS modules to run in Node. If building for
+        // Webpack 3, don't compile modules so we can use scope hoisting.
+        modules: runningTests ? 'commonjs' : false,
+
+        // If enabled, bundle 'core-js' polyfills for any features
+        // that we use into the build.
+        ...polyfillSettings
+      }],
+      require('@babel/preset-react'),
+    ],
+    plugins: [
+      require('@babel/plugin-transform-runtime'),
+      require('@babel/plugin-proposal-object-rest-spread'),
+      require('@babel/plugin-proposal-class-properties'),
+      require('@babel/plugin-syntax-dynamic-import'),
+      require('@babel/plugin-proposal-export-default-from'),
+      require('@babel/plugin-proposal-export-namespace-from'),
+      require('babel-plugin-graphql-tag'),
+      require('babel-plugin-lodash'),
+    ],
+    env: {
+      production: {
+        plugins: [
+          require('@babel/plugin-transform-react-constant-elements'),
+          require('babel-plugin-transform-react-remove-prop-types'),
+        ],
       },
-      // Jest needs CommonJS modules to run in Node. If building for
-      // Webpack 3, don't compile modules so we can use scope hoisting.
-      modules: runningTests ? 'commonjs' : false,
-      // Replace 'babel-polyfill' with only polyfills for target browsers.
-      useBuiltIns: 'usage',
-      corejs: 3,
-    }],
-    require('@babel/preset-react'),
-  ],
-  plugins: [
-    require('@babel/plugin-transform-runtime'),
-    require('@babel/plugin-proposal-object-rest-spread'),
-    require('@babel/plugin-proposal-class-properties'),
-    require('@babel/plugin-syntax-dynamic-import'),
-    require('@babel/plugin-proposal-export-default-from'),
-    require('@babel/plugin-proposal-export-namespace-from'),
-    require('babel-plugin-graphql-tag'),
-    require('babel-plugin-lodash'),
-  ],
-  env: {
-    production: {
-      plugins: [
-        require('@babel/plugin-transform-react-constant-elements'),
-        require('babel-plugin-transform-react-remove-prop-types'),
-      ],
+      test: {
+        plugins: [
+          require('babel-plugin-dynamic-import-node'),
+        ],
+      },
     },
-    test: {
-      plugins: [
-        require('babel-plugin-dynamic-import-node'),
-      ],
-    },
-  },
-});
+  }
+};


### PR DESCRIPTION
This pull request adds a `withPolyfills` option to opt out of including `core-js` polyfills in the compiled bundle. This allows us to load these conditionally via [polyfill.io](https://polyfill.io/v3/) in Phoenix.